### PR TITLE
Attach nostr metadata as profile to didDocumentMetdata

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -29,6 +29,7 @@ export class BlockcoreDidResolver {
 
     const pool = new SimplePool();
     const services = [] as any[];
+    let profile = null;
 
     const metadata = await pool.get(this.#relays, {
       kinds: [kinds.Metadata],
@@ -43,8 +44,8 @@ export class BlockcoreDidResolver {
     pool.close(this.#relays);
 
     if (metadata?.content) {
-      const metadataObject = JSON.parse(metadata.content);
-      const website = metadataObject.website;
+      profile = JSON.parse(metadata.content);
+      const website = profile.website;
 
       if (website) {
         services.push({
@@ -55,7 +56,7 @@ export class BlockcoreDidResolver {
       }
 
       // TODO: Is there any use putting NIP05 in DID Document?
-      // const nip05 = metadataObject.nip05;
+      // const nip05 = profile.nip05;
       // if (nip05) {
       // 	services.push({
       // 		id: `${parsed.did}#nip05`,
@@ -86,7 +87,10 @@ export class BlockcoreDidResolver {
         retrieved: new Date().toISOString(),
       },
       didDocumentMetadata: {
+        created: profile?.created_at,
+        updated: profile?.created_at,
         deactivated: false, // TODO: Check if the key is deactivated.
+        profile
       },
     };
 

--- a/test/identity.test.js
+++ b/test/identity.test.js
@@ -26,6 +26,8 @@ test('Create the resolver', async t => {
 
   t.assert(didResolution.didDocument.verificationMethod[0].publicKeyMultibase == 'z6DtPPzVD8nXDKTHG3x8cx8UpoVP6VSBsXaDhSWcoysUnkEY');
   t.assert(didResolution.didDocument.service[0].serviceEndpoint == 'https://sondreb.com');
+  t.assert(didResolution.didDocumentMetadata.profile !== null);
+  t.assert(didResolution.didDocumentMetadata.profile.name == 'sondreb');
 
   didResolution = await resolver.resolve('null');
   t.assert(didResolution.didResolutionMetadata.error == 'invalidDid');
@@ -53,4 +55,6 @@ test('Verify relay without profile or relay list', async t => {
 
   t.assert(didResolution.didDocument.verificationMethod[0].publicKeyMultibase == 'z6DtPPzVD8nXDKTHG3x8cx8UpoVP6VSBsXaDhSWcoysUnkEY');
   t.assert(didResolution.didDocument.service.length == 0);
+
+  t.assert(didResolution.didDocumentMetadata.profile == null);
 });


### PR DESCRIPTION
- This profile can be useful for apps and services that import the DID subject to name imported identities.