### PR TITLE
Fix relay serviceEndpoint URLs to include trailing slash

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -8,7 +8,7 @@ export function getResolver(relays?: string[]): Record<string, DIDResolver> {
 }
 
 export class BlockcoreDidResolver {
-  #relays = ['wss://relay.damus.io', 'wss://relay.primal.net', 'wss://nos.lol'];
+  #relays = ['wss://relay.damus.io/', 'wss://relay.primal.net/', 'wss://nos.lol/'];
 
   constructor(relays?: string[]) {
     if (relays) {
@@ -43,10 +43,12 @@ export class BlockcoreDidResolver {
       relayUrls = relays.tags.filter(tag => tag.length >= 2 && tag[0] === 'r').map(tag => tag[1]);
 
       for (let i = 0; i < relayUrls.length; i++) {
+        // Ensure trailing slash per DID Nostr spec requirement
+        const relayUrl = relayUrls[i].endsWith('/') ? relayUrls[i] : relayUrls[i] + '/';
         services.push({
           id: `${parsed.did}#${i + 1}`,
           type: 'Relay',
-          serviceEndpoint: relayUrls[i],
+          serviceEndpoint: relayUrl,
         });
       }
     }


### PR DESCRIPTION
## Summary
- Add trailing slashes to default relay URLs
- Ensure user-provided relay URLs get trailing slash appended when constructing DID documents

## Motivation
Per the [DID Nostr specification](https://nostrcg.github.io/did-nostr/#service-field-for-relays):

> Relay URLs at the origin level MUST include a trailing slash (e.g., `wss://relay.example.com/`).

## Before
```json
"serviceEndpoint": "wss://relay.damus.io"
```

## After
```json
"serviceEndpoint": "wss://relay.damus.io/"
```

## Test plan
- [ ] Verify resolved DID documents have trailing slashes on relay URLs
- [ ] Verify existing tests pass

Fixes #5